### PR TITLE
default external encoding set to utf-8

### DIFF
--- a/src/info.plist
+++ b/src/info.plist
@@ -78,7 +78,9 @@
 				<key>runningsubtext</key>
 				<string>Looking for notes...</string>
 				<key>script</key>
-				<string># coding: utf-8
+        <string># coding: utf-8
+Encoding.default_external = "utf-8"
+
 require 'json'
 require 'cgi'
 ENV['GEM_HOME'] = 'gems'


### PR DESCRIPTION
The following line is added at the top of the ruby code:

```
Encoding.default_external = "utf-8"
```

This prevents the InvalidByteSequenceError when the workflow deals with text in Japanese (and possibly some other languages).

```
[ERROR: alfred.workflow.input.scriptfilter] Code 1: /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/json/common.rb:155:in `encode': "\xE6" on US-ASCII (Encoding::InvalidByteSequenceError)
    from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/json/common.rb:155:in `initialize'
    from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/json/common.rb:155:in `new'
    from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/json/common.rb:155:in `parse'
    from -e:47:in `block in <main>'
    from -e:42:in `map'
    from -e:42:in `<main>'
```
